### PR TITLE
Rust: Update spec file to 1.2

### DIFF
--- a/rust/rust-binary.spec
+++ b/rust/rust-binary.spec
@@ -2,8 +2,8 @@
 # binaries.  Based on the spec file extracted from the
 # SRPM in https://copr.fedoraproject.org/coprs/fabiand/rust-binary/builds/
 
-%global rust_version 1.1.0
-%global rust_version_upstream 1.1.0
+%global rust_version 1.2.0
+%global rust_version_upstream 1.2.0
 %global archsuffix x86_64-unknown-linux-gnu
 
 %global debug_package %{nil}
@@ -12,7 +12,7 @@
 
 Name:           rust-binary
 Version:        %{rust_version}
-Release:        2%{?dist}
+Release:        1%{?dist}
 Summary:        The Rust Programming Language (official static build)
 
 License:        ASL 2.0, MIT
@@ -73,6 +73,9 @@ rm %{buildroot}/%{_libdir}/rustlib/install.log
 
 
 %changelog
+* Sat Jun 27 2015 Mattias Bengtsson <mattias.jc.bengtsson@gmail.com> - 1.2.0-1
+- Update to 1.2.0
+
 * Sat Jun 27 2015 Colin Walters <walters@verbum.org> - 1.1.0-2
 - Update to 1.1.0
 


### PR DESCRIPTION
Update the Rust binary spec file to the 1.2.0 release.